### PR TITLE
fix: avoid alloc on fill to capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Don't allocate if the queue is filled exactly to capacity.
+
 ## 0.1.0 - 2023-04-02
 
 - Initial release.

--- a/q.go
+++ b/q.go
@@ -32,7 +32,10 @@ func NewQ[T any](capacity int) *Q[T] {
 	if capacity == 0 {
 		capacity = _defaultCapacity
 	}
-	return &Q[T]{buff: make([]T, capacity)}
+	// Allocate requested capacity plus one slot
+	// so that filling the queue to exactly the requested capacity
+	// doesn't require resizing.
+	return &Q[T]{buff: make([]T, capacity+1)}
 }
 
 // Empty returns true if the queue is empty.

--- a/q_int_test.go
+++ b/q_int_test.go
@@ -1,0 +1,19 @@
+package ring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies that a queue filled exactly to capacity does not resize.
+func TestQ_fillNoResize(t *testing.T) {
+	t.Parallel()
+
+	q := NewQ[int](3)
+	initCap := cap(q.buff)
+	q.Push(1)
+	q.Push(2)
+	q.Push(3)
+	assert.Equal(t, initCap, cap(q.buff), "capacity")
+}


### PR DESCRIPTION
We resize after a Push if the queue buffer is full.
This ensures that head and tail only meet if the queue is empty
so there's no need to otherwise differentiate between empty and full.

This introduces a small annoyance, though:
if one uses `NewQ(5)` and adds 5 items to the queue,
they expect no allocations,
but the current implementation will allocate.

Resolve this by always allocating N+1 slots
so that a full queue doesn't resize.
