### PR TITLE
feat: Add MuQ, a thread-safe variant

### DIFF
--- a/.changes/unreleased/Added-20230407-165058.yaml
+++ b/.changes/unreleased/Added-20230407-165058.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add MuQ, a thread-safe variant of Q with a similar API.
+time: 2023-04-07T16:50:58.936235122-04:00

--- a/bench_test.go
+++ b/bench_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.abhg.dev/container/ring"
 )
 
@@ -13,6 +14,17 @@ func BenchmarkQ_pushPop_sameRate(b *testing.B) {
 		q.Push(i)
 		q.Pop()
 	}
+}
+
+func BenchmarkMuQ_pushPop_sameRate(b *testing.B) {
+	var q ring.MuQ[int]
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			q.Push(i)
+			_, ok := q.TryPop()
+			require.True(b, ok)
+		}
+	})
 }
 
 func BenchmarkQ_push_burst(b *testing.B) {
@@ -30,6 +42,28 @@ func BenchmarkQ_push_burst(b *testing.B) {
 					q.Pop()
 				}
 			}
+		})
+	}
+}
+
+func BenchmarkMuQ_push_burst(b *testing.B) {
+	bursts := []int{1, 10, 100}
+
+	for _, burst := range bursts {
+		name := fmt.Sprintf("burst=%d", burst)
+		b.Run(name, func(b *testing.B) {
+			var q ring.MuQ[int]
+			b.RunParallel(func(pb *testing.PB) {
+				for i := 0; pb.Next(); i++ {
+					for j := 0; j < burst; j++ {
+						q.Push(i)
+					}
+					for j := 0; j < burst; j++ {
+						_, ok := q.TryPop()
+						require.True(b, ok)
+					}
+				}
+			})
 		})
 	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -7,7 +7,7 @@ import (
 	"go.abhg.dev/container/ring"
 )
 
-func BenchmarkPushPop_sameRate(b *testing.B) {
+func BenchmarkQ_pushPop_sameRate(b *testing.B) {
 	var q ring.Q[int]
 	for i := 0; i < b.N; i++ {
 		q.Push(i)
@@ -15,7 +15,7 @@ func BenchmarkPushPop_sameRate(b *testing.B) {
 	}
 }
 
-func BenchmarkPush_burst(b *testing.B) {
+func BenchmarkQ_push_burst(b *testing.B) {
 	bursts := []int{1, 10, 100}
 
 	for _, burst := range bursts {

--- a/example_test.go
+++ b/example_test.go
@@ -37,3 +37,19 @@ func ExampleQ_TryPop_loop() {
 	// 1
 	// 2
 }
+
+func ExampleMuQ_TryPop_loop() {
+	var q ring.MuQ[int]
+	for i := 0; i < 3; i++ {
+		q.Push(i)
+	}
+
+	for v, ok := q.TryPop(); ok; v, ok = q.TryPop() {
+		fmt.Println(v)
+	}
+
+	// Output:
+	// 0
+	// 1
+	// 2
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -3,9 +3,10 @@ package ring_test
 import (
 	"testing"
 
+	"go.abhg.dev/container/ring"
 	"pgregory.net/rapid"
 )
 
 func FuzzQ_rapid(f *testing.F) {
-	f.Fuzz(rapid.MakeFuzz(rapid.Run[*qMachine]()))
+	f.Fuzz(rapid.MakeFuzz(rapid.Run[*qMachine[*ring.Q[int]]]()))
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -10,3 +10,7 @@ import (
 func FuzzQ_rapid(f *testing.F) {
 	f.Fuzz(rapid.MakeFuzz(rapid.Run[*qMachine[*ring.Q[int]]]()))
 }
+
+func FuzzMuQ_rapid(f *testing.F) {
+	f.Fuzz(rapid.MakeFuzz(rapid.Run[*qMachine[*ring.MuQ[int]]]()))
+}

--- a/muq.go
+++ b/muq.go
@@ -1,0 +1,105 @@
+package ring
+
+import "sync"
+
+// MuQ is a thread-safe FIFO queue backed by a ring buffer.
+// The zero value for MuQ is an empty queue ready to use.
+//
+// MuQ is safe for concurrent use.
+// If you need to use it from a single goroutine, use [Q] instead.
+type MuQ[T any] struct {
+	mu sync.RWMutex
+	q  Q[T]
+}
+
+// The API for MuQ differs from Q somewhat:
+//
+// - There's no Do method because we don't want to hold onto a lock
+//   while we wait for a user-specified callback
+// - There's no panicking Pop or Peek method because
+//   if the queue is read from concurrently,
+//   verifying that it's non-empty and removing the entry
+//   must be a single atomic operation,
+//   which means users will only need Try variants,
+//   and having the panicking versions will just cause bugs.
+
+// NewMuQ returns a new thread-safe queue with the given capacity.
+func NewMuQ[T any](capacity int) *MuQ[T] {
+	var m MuQ[T]
+	m.q.init(capacity)
+	return &m
+}
+
+// Empty returns true if the queue is empty.
+//
+// This is an O(1) operation and does not allocate.
+func (q *MuQ[T]) Empty() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.q.Empty()
+}
+
+// Len returns the number of items in the queue.
+//
+// This is an O(1) operation and does not allocate.
+func (q *MuQ[T]) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.q.Len()
+}
+
+// Clear removes all items from the queue.
+// It does not adjust its internal capacity.
+//
+// This is an O(1) operation and does not allocate.
+func (q *MuQ[T]) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.q.Clear()
+}
+
+// Push adds x to the back of the queue.
+//
+// This operation is O(n) in the worst case if the queue needs to grow.
+// However, for target use cases, it's amortized O(1).
+// See package documentation for details.
+// If your usage pattern is bursts of pushes followed by bursts of pops,
+func (q *MuQ[T]) Push(x T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.q.Push(x)
+}
+
+// TryPop removes and returns the item at the front of the queue.
+// It returns false if the queue is empty.
+// Otherwise, it returns true and the item.
+//
+// This is an O(1) operation and does not allocate.
+func (q *MuQ[T]) TryPop() (x T, ok bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.q.TryPop()
+}
+
+// TryPeek returns the item at the front of the queue.
+// It returns false if the queue is empty.
+// Otherwise, it returns true and the item.
+//
+// This is an O(1) operation and does not allocate.
+func (q *MuQ[T]) TryPeek() (x T, ok bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.q.TryPeek()
+}
+
+// Snapshot appends the contents of the queue to dst and returns the result.
+//
+// Use dst to avoid allocations when you know the capacity of the queue
+// or pass nil to let the function allocate a new slice.
+//
+// The returned slice is a copy of the internal buffer and is safe to modify.
+func (q *MuQ[T]) Snapshot(dst []T) []T {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.q.Snapshot(dst)
+}

--- a/muq_race_test.go
+++ b/muq_race_test.go
@@ -1,0 +1,54 @@
+package ring_test
+
+import (
+	"sync"
+	"testing"
+
+	"go.abhg.dev/container/ring"
+)
+
+// Runs a few goroutines calling the different methods on MuQ concurrently.
+func TestMuQ_race(t *testing.T) {
+	const (
+		// Number of times each function should be called.
+		Steps = 1000
+
+		// Number of goroutines calling each function.
+		Workers = 10
+	)
+
+	var q ring.MuQ[int]
+	funcs := []func(){
+		func() { q.Empty() },
+		func() { q.Len() },
+		q.Clear,
+		func() { q.Push(0) },
+		func() { q.TryPop() },
+		func() { q.TryPeek() },
+		func() { q.Snapshot(nil) },
+	}
+
+	var (
+		ready sync.WaitGroup // to block start
+		done  sync.WaitGroup // to wait for end
+	)
+	for _, fn := range funcs {
+		fn := fn
+		done.Add(Workers)
+		ready.Add(Workers)
+		for i := 0; i < Workers; i++ {
+			go func() {
+				defer done.Done()
+
+				ready.Done() // I'm ready...
+				ready.Wait() // ...is everone else?
+
+				for step := 0; step < Steps; step++ {
+					fn()
+				}
+			}()
+		}
+	}
+
+	done.Wait()
+}

--- a/q.go
+++ b/q.go
@@ -6,8 +6,7 @@ const _defaultCapacity = 16
 // The zero value for Q is an empty queue ready to use.
 //
 // Q is not safe for concurrent use.
-// If you need to use it from multiple goroutines,
-// synchronize access to the queue using a mutex.
+// If you need to use it from multiple goroutines, use [MuQ] instead.
 type Q[T any] struct {
 	// buff is the ring buffer.
 	//
@@ -29,13 +28,21 @@ type Q[T any] struct {
 // The capacity defines the leeway for bursts of pushes
 // before the queue needs to grow.
 func NewQ[T any](capacity int) *Q[T] {
+	var q Q[T]
+	q.init(capacity)
+	return &q
+}
+
+func (q *Q[T]) init(capacity int) {
 	if capacity == 0 {
 		capacity = _defaultCapacity
 	}
 	// Allocate requested capacity plus one slot
 	// so that filling the queue to exactly the requested capacity
 	// doesn't require resizing.
-	return &Q[T]{buff: make([]T, capacity+1)}
+	q.buff = make([]T, capacity+1)
+	q.head = 0
+	q.tail = 0
 }
 
 // Empty returns true if the queue is empty.

--- a/q_test.go
+++ b/q_test.go
@@ -1,0 +1,80 @@
+package ring_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.abhg.dev/container/ring"
+)
+
+func TestQ_empty(t *testing.T) {
+	t.Parallel()
+
+	var q ring.Q[int]
+	assert.Panics(t, func() { q.Peek() }, "peek")
+	assert.Panics(t, func() { q.Pop() }, "pop")
+
+	q.Do(func(i int) bool {
+		t.Errorf("unexpected item: %v", i)
+		return true
+	})
+}
+
+func TestQ_PeekPop(t *testing.T) {
+	t.Parallel()
+
+	var q ring.Q[int]
+	q.Push(42)
+	assert.Equal(t, 42, q.Peek(), "peek")
+	assert.Equal(t, 42, q.Pop(), "pop")
+	assert.True(t, q.Empty(), "empty")
+}
+
+func TestQ_Do(t *testing.T) {
+	t.Parallel()
+
+	const NumItems = 100
+	var q ring.Q[int]
+
+	want := make([]int, 0, NumItems)
+	for i := 0; i < NumItems; i++ {
+		q.Push(i)
+		want = append(want, i)
+	}
+
+	got := make([]int, 0, NumItems)
+	q.Do(func(i int) bool {
+		got = append(got, i)
+		return true
+	})
+
+	assert.Equal(t, want, got, "do did not iterate fully")
+}
+
+func TestQ_Do_returnEarly(t *testing.T) {
+	t.Parallel()
+
+	const NumItems = 100
+	var q ring.Q[int]
+
+	stopAt := NumItems / 2
+	want := make([]int, 0, NumItems)
+	for i := 0; i < NumItems; i++ {
+		q.Push(i)
+		if i < stopAt {
+			want = append(want, i)
+		}
+	}
+
+	got := make([]int, 0, stopAt)
+	q.Do(func(i int) bool {
+		if i >= stopAt {
+			return false
+		}
+
+		got = append(got, i)
+		return true
+	})
+
+	assert.Equal(t, want, got, "iterated over unexpected items")
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -20,6 +20,14 @@ func TestQ(t *testing.T) {
 	})
 }
 
+func TestMuQ(t *testing.T) {
+	t.Parallel()
+
+	testQueueSuite(t, func(capacity int) queue[int] {
+		return ring.NewMuQ[int](capacity)
+	})
+}
+
 type queue[T any] interface {
 	Empty() bool
 	Len() int
@@ -30,7 +38,10 @@ type queue[T any] interface {
 	Snapshot([]T) []T
 }
 
-var _ queue[int] = (*ring.Q[int])(nil)
+var (
+	_ queue[int] = (*ring.Q[int])(nil)
+	_ queue[int] = (*ring.MuQ[int])(nil)
+)
 
 func testQueueSuite(t *testing.T, newWithCap func(capacity int) queue[int]) {
 	capacities := []int{

--- a/rapid_test.go
+++ b/rapid_test.go
@@ -15,6 +15,12 @@ func TestQ_rapid(t *testing.T) {
 	rapid.Check(t, rapid.Run[*qMachine[*ring.Q[int]]]())
 }
 
+func TestMuQ_rapid(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, rapid.Run[*qMachine[*ring.MuQ[int]]]())
+}
+
 type qMachine[QT queue[int]] struct {
 	q QT
 
@@ -30,6 +36,8 @@ func (m *qMachine[QT]) Init(t *rapid.T) {
 	switch queue[int](*new(QT)).(type) {
 	case *ring.Q[int]:
 		q = ring.NewQ[int](capacity)
+	case *ring.MuQ[int]:
+		q = ring.NewMuQ[int](capacity)
 	default:
 		t.Fatalf("cannot instantiate queue type: %T", *new(QT))
 	}


### PR DESCRIPTION
MuQ is a thread-safe variant of Q
with a slightly different API.

Specifically,
it lacks a Do method because we don't want to lock the queue
while an arbitrary user-specified callback runs.

And it does not include panicking Pop and Peep variants
because it's impossible to write code that uses them safely
without additional external locking:

```go
for !muq.Empty() {
  muq.Pop()
}
```

This will panic if run from two goroutines because there's a race
between `Empty()` and `Pop()`.
