### PR TITLE
Q: Remove Do method

### DIFF
--- a/.changes/unreleased/Removed-20230415-122605.yaml
+++ b/.changes/unreleased/Removed-20230415-122605.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: Drop Q.Do method. Modifying the queue while iterating leads to unexpected behavior.
+time: 2023-04-15T12:26:05.940172193-07:00

--- a/muq.go
+++ b/muq.go
@@ -14,14 +14,12 @@ type MuQ[T any] struct {
 
 // The API for MuQ differs from Q somewhat:
 //
-// - There's no Do method because we don't want to hold onto a lock
-//   while we wait for a user-specified callback
-// - There's no panicking Pop or Peek method because
-//   if the queue is read from concurrently,
-//   verifying that it's non-empty and removing the entry
-//   must be a single atomic operation,
-//   which means users will only need Try variants,
-//   and having the panicking versions will just cause bugs.
+// There's no panicking Pop or Peek method because
+// if the queue is read from concurrently,
+// verifying that it's non-empty and removing the entry
+// must be a single atomic operation,
+// which means users will only need Try variants,
+// and having the panicking versions will just cause bugs.
 
 // NewMuQ returns a new thread-safe queue with the given capacity.
 func NewMuQ[T any](capacity int) *MuQ[T] {

--- a/q.go
+++ b/q.go
@@ -181,27 +181,3 @@ func (q *Q[T]) Snapshot(dst []T) []T {
 	dst = append(dst, q.buff[q.head:]...)
 	return append(dst, q.buff[:q.tail]...)
 }
-
-// Do calls f for each item in the queue, from front to back.
-// It stops if f returns false.
-//
-// This is an O(n) operation and does not allocate.
-func (q *Q[T]) Do(f func(T) (proceed bool)) {
-	if q.head <= q.tail {
-		sliceDo(q.buff[q.head:q.tail], f)
-		return
-	}
-
-	if sliceDo(q.buff[q.head:], f) {
-		sliceDo(q.buff[:q.tail], f)
-	}
-}
-
-func sliceDo[T any](s []T, f func(T) (proceed bool)) bool {
-	for _, x := range s {
-		if !f(x) {
-			return false
-		}
-	}
-	return true
-}

--- a/q_test.go
+++ b/q_test.go
@@ -11,13 +11,11 @@ func TestQ_empty(t *testing.T) {
 	t.Parallel()
 
 	var q ring.Q[int]
+	assert.True(t, q.Empty(), "empty")
+	assert.Zero(t, q.Len(), "len")
 	assert.Panics(t, func() { q.Peek() }, "peek")
 	assert.Panics(t, func() { q.Pop() }, "pop")
-
-	q.Do(func(i int) bool {
-		t.Errorf("unexpected item: %v", i)
-		return true
-	})
+	assert.Empty(t, q.Snapshot(nil), "snapshot")
 }
 
 func TestQ_PeekPop(t *testing.T) {
@@ -28,53 +26,4 @@ func TestQ_PeekPop(t *testing.T) {
 	assert.Equal(t, 42, q.Peek(), "peek")
 	assert.Equal(t, 42, q.Pop(), "pop")
 	assert.True(t, q.Empty(), "empty")
-}
-
-func TestQ_Do(t *testing.T) {
-	t.Parallel()
-
-	const NumItems = 100
-	var q ring.Q[int]
-
-	want := make([]int, 0, NumItems)
-	for i := 0; i < NumItems; i++ {
-		q.Push(i)
-		want = append(want, i)
-	}
-
-	got := make([]int, 0, NumItems)
-	q.Do(func(i int) bool {
-		got = append(got, i)
-		return true
-	})
-
-	assert.Equal(t, want, got, "do did not iterate fully")
-}
-
-func TestQ_Do_returnEarly(t *testing.T) {
-	t.Parallel()
-
-	const NumItems = 100
-	var q ring.Q[int]
-
-	stopAt := NumItems / 2
-	want := make([]int, 0, NumItems)
-	for i := 0; i < NumItems; i++ {
-		q.Push(i)
-		if i < stopAt {
-			want = append(want, i)
-		}
-	}
-
-	got := make([]int, 0, stopAt)
-	q.Do(func(i int) bool {
-		if i >= stopAt {
-			return false
-		}
-
-		got = append(got, i)
-		return true
-	})
-
-	assert.Equal(t, want, got, "iterated over unexpected items")
 }

--- a/rapid_test.go
+++ b/rapid_test.go
@@ -126,20 +126,3 @@ func (m *qMachine[QT]) Snapshot(t *rapid.T) {
 		assert.Equal(t, e.Value, got[i])
 	}
 }
-
-func (m *qMachine[QT]) Do(t *rapid.T) {
-	doer, ok := any(m.q).(interface{ Do(func(int) bool) })
-	if !ok {
-		t.Skip()
-	}
-
-	el := m.golden.Front()
-	doer.Do(func(x int) bool {
-		assert.Equal(t, el.Value, x)
-		if rapid.Bool().Draw(t, "proceed") {
-			el = el.Next()
-			return true
-		}
-		return false
-	})
-}


### PR DESCRIPTION
The Q.Do method makes it easy to make mistakes:
if you modify the queue (Push or Pop) from inside the function,
it can lead to unexpected behavior in the queue.
Rather than try to guard against this, just remove the function.
If someone wants to iterate through all items without popping,
they can use Snapshot.
